### PR TITLE
[codex] add competition setup flow before starting a game

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Instead of storing only the latest match score, it stores each match action as a
 
 The core domain includes:
 
-- Championships and games
+- Competitions and games
 - Teams, players, staff, and officials assigned to a game
 - An event stream (`game_events`) for everything that happens during a match
 - Materialized state snapshots (`game_state_snapshots`) for fast reads

--- a/app/Livewire/Competition.php
+++ b/app/Livewire/Competition.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire;
+
+use App\Models\Competition as CompetitionModel;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+#[Title('Competition')]
+class Competition extends Component
+{
+    public string $name = '';
+
+    public bool $saved = false;
+
+    public function mount(): void
+    {
+        $competition = CompetitionModel::current();
+
+        $this->name = $competition !== null
+            ? $competition->name
+            : config('competition.name');
+    }
+
+    public function save(): void
+    {
+        $this->name = trim($this->name);
+
+        $validated = $this->validate([
+            'name' => ['required', 'string', 'max:255'],
+        ]);
+
+        $competition = CompetitionModel::ensureSingleton();
+        $competition->forceFill([
+            'name' => trim((string) $validated['name']),
+        ])->save();
+
+        $this->name = $competition->name;
+        $this->saved = true;
+    }
+
+    public function updatedName(): void
+    {
+        $this->saved = false;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.competition');
+    }
+}

--- a/app/Livewire/MatchSetup.php
+++ b/app/Livewire/MatchSetup.php
@@ -8,6 +8,7 @@ use App\Enums\OfficialRole;
 use App\Enums\StaffRole;
 use App\Enums\TeamAB;
 use App\Exceptions\InvalidGameEventTransition;
+use App\Models\Competition;
 use App\Models\Game;
 use App\Models\Official;
 use App\Models\Player;
@@ -16,7 +17,6 @@ use App\Models\Team;
 use App\Services\CurrentMatchResolver;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 
@@ -25,6 +25,10 @@ class MatchSetup extends Component
     public ?Game $game = null;
 
     public string $step = 'missing-match';
+
+    public string $competitionName = '';
+
+    public bool $editingCompetition = false;
 
     public string $matchNumber = '';
 
@@ -71,11 +75,46 @@ class MatchSetup extends Component
 
     public function mount(CurrentMatchResolver $currentMatchResolver): void
     {
+        $this->synchronizeCompetitionState();
         $this->synchronizeState($currentMatchResolver->current());
+    }
+
+    public function saveCompetition(): void
+    {
+        $this->competitionName = trim($this->competitionName);
+
+        $validated = $this->validate([
+            'competitionName' => ['required', 'string', 'max:255'],
+        ]);
+
+        $competition = Competition::ensureSingleton();
+        $competition->forceFill([
+            'name' => trim((string) $validated['competitionName']),
+        ])->save();
+
+        $this->editingCompetition = false;
+        $this->synchronizeCompetitionState();
+        $this->synchronizeState($this->game?->fresh(['homeTeam', 'awayTeam', 'officials']));
+    }
+
+    public function editCompetition(): void
+    {
+        if (! Competition::setupComplete()) {
+            return;
+        }
+
+        $this->editingCompetition = true;
+        $this->step = 'competition';
     }
 
     public function createMatch(): void
     {
+        if (! Competition::setupComplete()) {
+            $this->step = 'competition';
+
+            return;
+        }
+
         if ($this->game !== null) {
             $this->synchronizeState($this->game->fresh(['homeTeam', 'awayTeam', 'officials']));
 
@@ -87,7 +126,13 @@ class MatchSetup extends Component
 
     public function openStep(string $step): void
     {
-        if (! in_array($step, ['match-details', 'rosters', 'officials', 'ready'], true)) {
+        if (! in_array($step, ['competition', 'match-details', 'rosters', 'officials', 'ready'], true)) {
+            return;
+        }
+
+        if ($step === 'competition') {
+            $this->step = 'competition';
+
             return;
         }
 
@@ -102,7 +147,15 @@ class MatchSetup extends Component
         }
 
         $requiredStep = $this->resolver()->nextStep($this->game);
-        $availableSteps = ['match-details'];
+        $availableSteps = ['competition'];
+
+        if (! Competition::setupComplete()) {
+            $this->step = 'competition';
+
+            return;
+        }
+
+        $availableSteps[] = 'match-details';
 
         if ($this->game->hasCompleteMatchDetails()) {
             $availableSteps[] = 'rosters';
@@ -290,11 +343,13 @@ class MatchSetup extends Component
     public function render(): View
     {
         return view('livewire.match-setup', [
-            'competitionName' => $this->game?->competitionName() ?? Config::string('competition.name'),
+            'currentCompetitionName' => $this->game?->competitionName() ?? $this->competitionName,
+            'competitionConfigured' => Competition::setupComplete(),
             'currentRequiredStep' => $this->resolver()->nextStep($this->game),
             'isSetupComplete' => $this->game !== null && $this->resolver()->isSetupComplete($this->game),
             'isSetupLocked' => $this->setupLocked(),
             'setupSteps' => [
+                'competition' => 'Competition',
                 'match-details' => 'Match details',
                 'rosters' => 'Team rosters',
                 'officials' => 'Officials',
@@ -306,6 +361,16 @@ class MatchSetup extends Component
     private function synchronizeState(?Game $game): void
     {
         $this->game = $game;
+
+        if (! Competition::setupComplete()) {
+            $this->step = 'competition';
+
+            if ($game === null) {
+                $this->resetFormState();
+            }
+
+            return;
+        }
 
         if ($game === null) {
             $this->step = 'missing-match';
@@ -361,6 +426,15 @@ class MatchSetup extends Component
         $this->homeStaffRows = $this->emptyStaffRows();
         $this->awayStaffRows = $this->emptyStaffRows();
         $this->officialRows = $this->emptyOfficialRows();
+    }
+
+    private function synchronizeCompetitionState(): void
+    {
+        $competition = Competition::current();
+
+        $this->competitionName = $competition !== null
+            ? $competition->name
+            : '';
     }
 
     /**

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Carbon\CarbonImmutable;
+use Database\Factories\CompetitionFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\MultipleRecordsFoundException;
+use LogicException;
+
+/**
+ * @property string $name
+ * @property CarbonImmutable|null $created_at
+ * @property CarbonImmutable|null $updated_at
+ */
+#[Fillable(['name'])]
+class Competition extends Model
+{
+    /** @use HasFactory<CompetitionFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    #[\Override]
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'immutable_datetime',
+            'updated_at' => 'immutable_datetime',
+        ];
+    }
+
+    public static function current(): ?self
+    {
+        try {
+            /** @var self */
+            return static::query()->sole();
+        } catch (ModelNotFoundException) {
+            return null;
+        } catch (MultipleRecordsFoundException $exception) {
+            throw new LogicException('The single-competition application found multiple competition records.', previous: $exception);
+        }
+    }
+
+    public static function ensureSingleton(): self
+    {
+        $competition = static::current();
+
+        if ($competition !== null) {
+            return $competition;
+        }
+
+        return static::query()->create([
+            'name' => config('competition.name'),
+        ]);
+    }
+
+    public static function setupComplete(): bool
+    {
+        $competition = static::current();
+
+        return $competition !== null && trim($competition->name) !== '';
+    }
+}

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -177,7 +177,11 @@ class Game extends Model
      */
     public function competitionName(): string
     {
-        return Config::string('competition.name');
+        $competition = Competition::current();
+
+        return $competition !== null
+            ? $competition->name
+            : Config::string('competition.name');
     }
 
     public function resetForSetup(): void

--- a/app/Services/CurrentMatchResolver.php
+++ b/app/Services/CurrentMatchResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\MatchPhase;
+use App\Models\Competition;
 use App\Models\Game;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\MultipleRecordsFoundException;
@@ -40,6 +41,10 @@ class CurrentMatchResolver
 
     public function landingRouteName(): string
     {
+        if (! Competition::setupComplete()) {
+            return 'match.setup';
+        }
+
         $currentGame = $this->current();
 
         if ($currentGame === null) {
@@ -53,6 +58,10 @@ class CurrentMatchResolver
 
     public function nextStep(?Game $game = null): string
     {
+        if (! Competition::setupComplete()) {
+            return 'competition';
+        }
+
         $currentGame = $game ?? $this->current();
 
         if ($currentGame === null) {
@@ -82,6 +91,8 @@ class CurrentMatchResolver
     {
         $currentGame = $game ?? $this->current();
 
-        return $currentGame !== null && $currentGame->status !== MatchPhase::Setup;
+        return Competition::setupComplete()
+            && $currentGame !== null
+            && $currentGame->status !== MatchPhase::Setup;
     }
 }

--- a/database/factories/CompetitionFactory.php
+++ b/database/factories/CompetitionFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Competition;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Competition>
+ */
+class CompetitionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->company(),
+        ];
+    }
+
+    public function named(string $name): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'name' => $name,
+        ]);
+    }
+}

--- a/database/migrations/2026_02_01_171038_create_competitions_table.php
+++ b/database/migrations/2026_02_01_171038_create_competitions_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('championships', function (Blueprint $table) {
+        Schema::create('competitions', function (Blueprint $table) {
             $table->id();
             $table->string('name');
             $table->timestamps();

--- a/database/migrations/2026_02_01_171119_create_games_table.php
+++ b/database/migrations/2026_02_01_171119_create_games_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('games', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('championship_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('competition_id')->constrained()->cascadeOnDelete();
             $table->foreignId('home_team_id')->constrained('teams')->cascadeOnDelete();
             $table->foreignId('away_team_id')->constrained('teams')->cascadeOnDelete();
             $table->unsignedTinyInteger('number');

--- a/database/migrations/2026_06_08_171247_refactor_schema_for_single_match_lifecycle.php
+++ b/database/migrations/2026_06_08_171247_refactor_schema_for_single_match_lifecycle.php
@@ -101,26 +101,26 @@ return new class extends Migration
             });
 
         Schema::table('games', function (Blueprint $table): void {
-            $table->dropForeign(['championship_id']);
-            $table->dropColumn('championship_id');
+            $table->dropForeign(['competition_id']);
+            $table->dropColumn('competition_id');
         });
 
         Schema::dropIfExists('game_player');
         Schema::dropIfExists('game_staff');
         Schema::dropIfExists('game_official');
-        Schema::dropIfExists('championships');
+        Schema::dropIfExists('competitions');
     }
 
     public function down(): void
     {
-        Schema::create('championships', function (Blueprint $table): void {
+        Schema::create('competitions', function (Blueprint $table): void {
             $table->id();
             $table->string('name');
             $table->timestamps();
         });
 
         Schema::table('games', function (Blueprint $table): void {
-            $table->foreignId('championship_id')->nullable()->after('id')->constrained()->cascadeOnDelete();
+            $table->foreignId('competition_id')->nullable()->after('id')->constrained()->cascadeOnDelete();
         });
 
         Schema::create('game_official', function (Blueprint $table): void {

--- a/database/migrations/2026_06_21_083853_create_competitions_table.php
+++ b/database/migrations/2026_06_21_083853_create_competitions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('competitions')) {
+            return;
+        }
+
+        Schema::create('competitions', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('competitions');
+    }
+};

--- a/resources/views/livewire/competition.blade.php
+++ b/resources/views/livewire/competition.blade.php
@@ -1,0 +1,42 @@
+<div class="min-h-screen bg-linear-to-br from-amber-50 via-white to-sky-50 px-4 py-8 sm:px-6 lg:px-8">
+    <div class="mx-auto flex w-full max-w-3xl flex-col gap-6">
+        <flux:card class="border border-slate-200/80 bg-white/90 p-6 shadow-sm backdrop-blur sm:p-8">
+            <div class="flex flex-col gap-4">
+                <div class="space-y-3">
+                    <flux:badge color="sky" inset="top bottom">Competition</flux:badge>
+                    <div class="space-y-2">
+                        <flux:heading size="xl">Set the competition details</flux:heading>
+                        <flux:text class="max-w-2xl">
+                            Keep the current competition name in the app instead of relying on config defaults.
+                        </flux:text>
+                    </div>
+                </div>
+
+                @if ($saved)
+                    <flux:callout color="green" icon="check-circle">
+                        Competition details saved.
+                    </flux:callout>
+                @endif
+            </div>
+        </flux:card>
+
+        <flux:card class="border border-slate-200/80 bg-white/90 p-6 shadow-sm sm:p-8">
+            <form wire:submit="save" class="space-y-6">
+                <flux:field>
+                    <flux:label>Competition name</flux:label>
+                    <flux:input wire:model.live="name" placeholder="e.g. Nations League Finals" />
+                    <flux:text>
+                        This name is used anywhere the app renders the current competition label.
+                    </flux:text>
+                    <flux:error name="name" />
+                </flux:field>
+
+                <div class="flex justify-end">
+                    <flux:button type="submit" variant="primary" wire:loading.attr="disabled" wire:target="save">
+                        Save competition
+                    </flux:button>
+                </div>
+            </form>
+        </flux:card>
+    </div>
+</div>

--- a/resources/views/livewire/match-setup.blade.php
+++ b/resources/views/livewire/match-setup.blade.php
@@ -1,40 +1,100 @@
-<div class="min-h-screen bg-slate-950 px-4 py-8 text-slate-100 sm:px-6">
+<div class="min-h-screen bg-linear-to-br from-stone-50 via-white to-sky-50 px-4 py-8 text-slate-900 sm:px-6">
     <div class="mx-auto max-w-7xl space-y-6">
-        <flux:card class="border border-white/10 bg-white/6 p-6 backdrop-blur sm:p-8">
-            <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-                <div class="space-y-3">
-                    <flux:badge color="amber" inset="top bottom">Match Setup</flux:badge>
-                    <div class="space-y-2">
-                        <flux:heading size="xl" class="text-white">Prepare the current match before play starts</flux:heading>
-                        <flux:text class="max-w-3xl text-slate-300">
-                            Competition metadata comes from app config. Enter the match details, both team rosters, and all officials here before recording tosses, lineups, or rallies.
-                        </flux:text>
-                    </div>
-                </div>
-
-                <div class="rounded-2xl border border-white/10 bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
-                    <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Competition</div>
-                    <div class="mt-1 font-medium text-white">{{ $competitionName }}</div>
-                </div>
+        <section class="space-y-5 px-1 py-2 sm:px-2">
+            <div class="space-y-2">
+                <flux:heading size="xl">Prepare the current match before play starts</flux:heading>
+                <flux:text class="text-base">
+                    Use this page to set up the match before it can begin.
+                </flux:text>
+                <flux:text class="text-base">
+                Start by saving the competition, then fill in the match details, enter both team rosters, and assign all required officials. Until those sections are complete, you will stay on setup and the scoring screen will remain unavailable.
+                </flux:text>
+                <flux:text class="text-base">
+                    Every section stays editable throughout setup. You can move back and forth between steps, adjust earlier information, and review what is still missing before the match becomes ready. Once setup is complete, you can open the match and begin recording tosses, lineups, rallies, and the rest of the live flow.
+                </flux:text>
             </div>
 
             @error('setup')
-                <flux:text class="mt-4 text-red-300">{{ $message }}</flux:text>
+                <flux:text class="mt-4">{{ $message }}</flux:text>
             @enderror
-        </flux:card>
+        </section>
 
-        @if ($step === 'missing-match')
-            <flux:card class="border border-white/10 bg-slate-900/70 p-8">
+        @if ($step === 'missing-match' || $step === 'competition')
+            <flux:card class="border border-slate-200/80 bg-white/90 p-8 shadow-sm">
+                @if (! $competitionConfigured)
+                    <form wire:submit="saveCompetition" class="space-y-5">
+                        <div class="space-y-2">
+                            <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Competition</div>
+                            <flux:heading size="lg">Competition details</flux:heading>
+                            <flux:text class="max-w-2xl">
+                                Save the current competition name before continuing with the match setup flow.
+                            </flux:text>
+                        </div>
+
+                        <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+                            <flux:field class="flex-1">
+                                <flux:label>Competition name</flux:label>
+                                <flux:input wire:model.live="competitionName" placeholder="e.g. Nations League Finals" />
+                                <flux:error name="competitionName" />
+                            </flux:field>
+
+                            <flux:button type="submit" variant="primary" class="sm:self-end">
+                                Save competition
+                            </flux:button>
+                        </div>
+                    </form>
+                @elseif ($editingCompetition)
+                    <form wire:submit="saveCompetition" class="space-y-5">
+                        <div class="space-y-2">
+                            <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Competition</div>
+                            <flux:input
+                                wire:model.live="competitionName"
+                                placeholder="e.g. Nations League Finals"
+                                class="max-w-xl"
+                            />
+                            <flux:text class="max-w-2xl">
+                                Update the competition name inline, then press Enter to save it.
+                            </flux:text>
+                            <flux:error name="competitionName" />
+                        </div>
+                    </form>
+                @else
+                    <div class="space-y-2">
+                        <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Competition</div>
+                        <div class="flex gap-4">
+                            <flux:heading>{{ $currentCompetitionName }}</flux:heading>
+                            <flux:button
+                                variant="subtle"
+                                size="xs"
+                                icon="pencil-square"
+                                inset
+                                square
+                                tooltip="Edit competition"
+                                wire:click="editCompetition"
+                            />
+                        </div>
+                        <flux:text class="max-w-2xl">
+                            Competition details are set. You can still edit them before setup is completed.
+                        </flux:text>
+                    </div>
+                @endif
+            </flux:card>
+
+            <flux:card class="border border-slate-200/80 bg-white/90 p-8 shadow-sm">
                 <div class="space-y-5">
                     <div class="space-y-2">
-                        <flux:heading size="lg" class="text-white">Create the current match</flux:heading>
-                        <flux:text class="max-w-2xl text-slate-300">
-                            The database does not have a current match yet. Create the singleton match record, then complete the setup flow.
+                        <flux:heading size="lg">Create the current match</flux:heading>
+                        <flux:text>
+                            @if ($competitionConfigured)
+                                The database does not have a current match yet. Create the singleton match record, then complete the remaining setup flow.
+                            @else
+                                After saving the competition, create the singleton match record here and continue through the setup flow.
+                            @endif
                         </flux:text>
                     </div>
 
                     <div class="flex justify-start">
-                        <flux:button variant="primary" wire:click="createMatch">
+                        <flux:button variant="primary" wire:click="createMatch" :disabled="! $competitionConfigured">
                             Create current match
                         </flux:button>
                     </div>
@@ -42,11 +102,11 @@
             </flux:card>
         @elseif ($game !== null)
             @php
-                $stepOrder = ['match-details', 'rosters', 'officials', 'ready'];
+                $stepOrder = ['competition', 'match-details', 'rosters', 'officials', 'ready'];
             @endphp
 
             <div class="grid gap-6 xl:grid-cols-[18rem_minmax(0,1fr)]">
-                <flux:card class="border border-white/10 bg-slate-900/70 p-4">
+                <flux:card class="border border-slate-200/80 bg-white/90 p-4 shadow-sm">
                     <div class="space-y-3">
                         @foreach ($setupSteps as $stepKey => $stepLabel)
                             @php
@@ -61,22 +121,22 @@
                                 wire:click="openStep('{{ $stepKey }}')"
                                 class="@class([
                                     'flex w-full items-center justify-between rounded-2xl border px-4 py-3 text-left transition',
-                                    'border-amber-400/60 bg-amber-500/10 text-white' => $isCurrent,
-                                    'border-emerald-400/40 bg-emerald-500/10 text-slate-100' => $isComplete && ! $isCurrent,
-                                    'border-white/10 bg-white/5 text-slate-300 hover:bg-white/10' => ! $isCurrent && ! $isComplete,
+                                    'border-amber-300 bg-amber-50 text-slate-950' => $isCurrent,
+                                    'border-emerald-200 bg-emerald-50 text-slate-900' => $isComplete && ! $isCurrent,
+                                    'border-slate-200 bg-white text-slate-600 hover:bg-slate-50' => ! $isCurrent && ! $isComplete,
                                 ])"
                             >
                                 <span class="font-medium">{{ $stepLabel }}</span>
-                                <span class="text-xs uppercase tracking-[0.18em] {{ $isComplete ? 'text-emerald-300' : ($isCurrent ? 'text-amber-200' : 'text-slate-500') }}">
+                                <span class="text-xs uppercase tracking-[0.18em] {{ $isComplete ? 'text-emerald-600' : ($isCurrent ? 'text-amber-700' : 'text-slate-500') }}">
                                     {{ $isComplete ? 'Done' : ($isCurrent ? 'Current' : 'Pending') }}
                                 </span>
                             </button>
                         @endforeach
                     </div>
 
-                    <div class="mt-6 rounded-2xl border border-white/10 bg-slate-950/60 p-4 text-sm text-slate-300">
+                    <div class="mt-6 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
                         <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Current Match</div>
-                        <div class="mt-2 font-medium text-white">
+                        <div class="mt-2 font-medium text-slate-950">
                             {{ $homeTeamName !== '' ? $homeTeamName : 'Home team' }}
                             <span class="text-slate-500">vs</span>
                             {{ $awayTeamName !== '' ? $awayTeamName : 'Away team' }}
@@ -89,18 +149,57 @@
 
                 <div class="space-y-6">
                     @if ($isSetupLocked)
-                        <flux:card class="border border-amber-400/20 bg-amber-500/10 p-5">
-                            <flux:heading size="sm" class="text-amber-100">Setup is locked</flux:heading>
-                            <flux:text class="mt-2 text-amber-50/90">
+                        <flux:card class="border border-amber-200 bg-amber-50 p-5 shadow-sm">
+                            <flux:heading size="sm">Setup is locked</flux:heading>
+                            <flux:text class="mt-2">
                                 Match details, rosters, and officials are read-only after the first match event is recorded. Review the summary below and continue scoring from the current match page.
                             </flux:text>
                         </flux:card>
+                    @elseif ($step === 'competition')
+                        <flux:card class="border border-slate-200/80 bg-white/90 p-6 shadow-sm">
+                            @if ($editingCompetition)
+                                <form wire:submit="saveCompetition" class="space-y-5">
+                                    <div class="space-y-2">
+                                        <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Competition</div>
+                                        <flux:input
+                                            wire:model.live="competitionName"
+                                            placeholder="e.g. Nations League Finals"
+                                            class="max-w-xl"
+                                        />
+                                        <flux:text>
+                                            Update the competition name inline, then press Enter to save it.
+                                        </flux:text>
+                                        <flux:error name="competitionName" />
+                                    </div>
+                                </form>
+                            @else
+                                <div class="space-y-2">
+                                    <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Competition</div>
+                                    <div class="flex items-end gap-2">
+                                        <flux:heading size="lg">{{ $currentCompetitionName }}</flux:heading>
+                                        <flux:button
+                                            type="button"
+                                            variant="ghost"
+                                            size="xs"
+                                            square
+                                            icon="pencil-square"
+                                            class="shrink-0"
+                                            tooltip="Edit competition"
+                                            wire:click="editCompetition"
+                                        />
+                                    </div>
+                                    <flux:text>
+                                        Competition details are set. You can still edit them before setup is completed.
+                                    </flux:text>
+                                </div>
+                            @endif
+                        </flux:card>
                     @elseif ($step === 'match-details')
-                        <flux:card class="border border-white/10 bg-slate-900/70 p-6">
+                        <flux:card class="border border-slate-200/80 bg-white/90 p-6 shadow-sm">
                             <form wire:submit="saveMatchDetails" class="space-y-6">
                                 <div class="space-y-2">
-                                    <flux:heading size="lg" class="text-white">Match details</flux:heading>
-                                    <flux:text class="text-slate-300">
+                                    <flux:heading size="lg">Match details</flux:heading>
+                                    <flux:text>
                                         Enter the static metadata for the one current match, including the home and away team identity.
                                     </flux:text>
                                 </div>
@@ -109,37 +208,37 @@
                                     <div>
                                         <flux:input wire:model="matchNumber" label="Match number" />
                                         @error('matchNumber')
-                                            <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                            <flux:text class="mt-1">{{ $message }}</flux:text>
                                         @enderror
                                     </div>
                                     <div>
                                         <flux:input wire:model="matchCountryCode" label="Host country code" />
                                         @error('matchCountryCode')
-                                            <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                            <flux:text class="mt-1">{{ $message }}</flux:text>
                                         @enderror
                                     </div>
                                     <div>
                                         <flux:input type="datetime-local" wire:model="matchDateTime" label="Scheduled at" />
                                         @error('matchDateTime')
-                                            <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                            <flux:text class="mt-1">{{ $message }}</flux:text>
                                         @enderror
                                     </div>
                                     <div>
                                         <flux:input wire:model="city" label="City" />
                                         @error('city')
-                                            <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                            <flux:text class="mt-1">{{ $message }}</flux:text>
                                         @enderror
                                     </div>
                                     <div>
                                         <flux:input wire:model="hall" label="Hall" />
                                         @error('hall')
-                                            <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                            <flux:text class="mt-1">{{ $message }}</flux:text>
                                         @enderror
                                     </div>
                                     <div>
                                         <flux:input wire:model="pool" label="Pool" />
                                         @error('pool')
-                                            <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                            <flux:text class="mt-1">{{ $message }}</flux:text>
                                         @enderror
                                     </div>
                                 </div>
@@ -158,41 +257,41 @@
                                 </div>
 
                                 @error('division')
-                                    <flux:text class="text-red-300">{{ $message }}</flux:text>
+                                    <flux:text>{{ $message }}</flux:text>
                                 @enderror
                                 @error('category')
-                                    <flux:text class="text-red-300">{{ $message }}</flux:text>
+                                    <flux:text>{{ $message }}</flux:text>
                                 @enderror
 
                                 <div class="grid gap-6 lg:grid-cols-2">
-                                    <div class="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-5">
-                                        <flux:heading size="sm" class="text-white">Home team</flux:heading>
+                                    <div class="space-y-4 rounded-2xl border border-slate-200 bg-slate-50 p-5">
+                                        <flux:heading size="sm">Home team</flux:heading>
                                         <div>
                                             <flux:input wire:model="homeTeamName" label="Team name" />
                                             @error('homeTeamName')
-                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                             @enderror
                                         </div>
                                         <div>
                                             <flux:input wire:model="homeTeamCountryCode" label="Country code" />
                                             @error('homeTeamCountryCode')
-                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                             @enderror
                                         </div>
                                     </div>
 
-                                    <div class="space-y-4 rounded-2xl border border-white/10 bg-white/5 p-5">
-                                        <flux:heading size="sm" class="text-white">Away team</flux:heading>
+                                    <div class="space-y-4 rounded-2xl border border-slate-200 bg-slate-50 p-5">
+                                        <flux:heading size="sm">Away team</flux:heading>
                                         <div>
                                             <flux:input wire:model="awayTeamName" label="Team name" />
                                             @error('awayTeamName')
-                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                             @enderror
                                         </div>
                                         <div>
                                             <flux:input wire:model="awayTeamCountryCode" label="Country code" />
                                             @error('awayTeamCountryCode')
-                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                             @enderror
                                         </div>
                                     </div>
@@ -204,11 +303,11 @@
                             </form>
                         </flux:card>
                     @elseif ($step === 'rosters')
-                        <flux:card class="border border-white/10 bg-slate-900/70 p-6">
+                        <flux:card class="border border-slate-200/80 bg-white/90 p-6 shadow-sm">
                             <form wire:submit="saveRosters" class="space-y-8">
                                 <div class="space-y-2">
-                                    <flux:heading size="lg" class="text-white">Home and away rosters</flux:heading>
-                                    <flux:text class="text-slate-300">
+                                    <flux:heading size="lg">Home and away rosters</flux:heading>
+                                    <flux:text>
                                         Enter the match roster directly for each team. Every listed player becomes part of the current match roster.
                                     </flux:text>
                                 </div>
@@ -218,11 +317,11 @@
                                         'home' => ['label' => $homeTeamName !== '' ? $homeTeamName : 'Home team', 'players' => $homePlayerRows, 'staff' => $homeStaffRows],
                                         'away' => ['label' => $awayTeamName !== '' ? $awayTeamName : 'Away team', 'players' => $awayPlayerRows, 'staff' => $awayStaffRows],
                                     ] as $side => $team)
-                                        <section class="space-y-5 rounded-3xl border border-white/10 bg-white/5 p-5">
+                                        <section class="space-y-5 rounded-3xl border border-slate-200 bg-slate-50 p-5">
                                             <div class="flex items-center justify-between gap-4">
                                                 <div>
-                                                    <flux:heading size="sm" class="text-white">{{ $team['label'] }}</flux:heading>
-                                                    <flux:text class="text-slate-400">Players, captain, libero selection, and bench staff.</flux:text>
+                                                    <flux:heading size="sm">{{ $team['label'] }}</flux:heading>
+                                                    <flux:text>Players, captain, libero selection, and bench staff.</flux:text>
                                                 </div>
                                                 <flux:button type="button" variant="ghost" wire:click="addPlayerRow('{{ $side }}')">
                                                     Add player
@@ -230,7 +329,7 @@
                                             </div>
 
                                             @error($side.'PlayerRows')
-                                                <flux:text class="text-red-300">{{ $message }}</flux:text>
+                                                <flux:text>{{ $message }}</flux:text>
                                             @enderror
 
                                             <div class="space-y-3">
@@ -248,19 +347,19 @@
                                                         <div>
                                                             <flux:input wire:model="{{ $side }}PlayerRows.{{ $index }}.first_name" />
                                                             @error($side.'PlayerRows.'.$index.'.first_name')
-                                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                                             @enderror
                                                         </div>
                                                         <div>
                                                             <flux:input wire:model="{{ $side }}PlayerRows.{{ $index }}.last_name" />
                                                             @error($side.'PlayerRows.'.$index.'.last_name')
-                                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                                             @enderror
                                                         </div>
                                                         <div>
                                                             <flux:input wire:model="{{ $side }}PlayerRows.{{ $index }}.number" />
                                                             @error($side.'PlayerRows.'.$index.'.number')
-                                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                                             @enderror
                                                         </div>
                                                         <div class="flex justify-center">
@@ -285,23 +384,23 @@
                                             </div>
 
                                             <div class="space-y-3">
-                                                <flux:heading size="xs" class="text-white">Bench staff</flux:heading>
+                                                <flux:heading size="xs">Bench staff</flux:heading>
 
                                                 @foreach ($team['staff'] as $index => $staffRow)
                                                     <div class="grid gap-3 md:grid-cols-[10rem_minmax(0,1fr)_minmax(0,1fr)]">
-                                                        <div class="rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm font-medium text-slate-200">
+                                                        <div class="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700">
                                                             {{ $staffRow['role'] }}
                                                         </div>
                                                         <div>
                                                             <flux:input wire:model="{{ $side }}StaffRows.{{ $index }}.first_name" placeholder="First name" />
                                                             @error($side.'StaffRows.'.$index.'.first_name')
-                                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                                             @enderror
                                                         </div>
                                                         <div>
                                                             <flux:input wire:model="{{ $side }}StaffRows.{{ $index }}.last_name" placeholder="Last name" />
                                                             @error($side.'StaffRows.'.$index.'.last_name')
-                                                                <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                                <flux:text class="mt-1">{{ $message }}</flux:text>
                                                             @enderror
                                                         </div>
                                                     </div>
@@ -317,31 +416,31 @@
                             </form>
                         </flux:card>
                     @elseif ($step === 'officials')
-                        <flux:card class="border border-white/10 bg-slate-900/70 p-6">
+                        <flux:card class="border border-slate-200/80 bg-white/90 p-6 shadow-sm">
                             <form wire:submit="saveOfficials" class="space-y-6">
                                 <div class="space-y-2">
-                                    <flux:heading size="lg" class="text-white">Officials</flux:heading>
-                                    <flux:text class="text-slate-300">
+                                    <flux:heading size="lg">Officials</flux:heading>
+                                    <flux:text>
                                         Enter the assigned officials for the scoresheet before moving into gameplay.
                                     </flux:text>
                                 </div>
 
                                 <div class="grid gap-4 lg:grid-cols-2">
                                     @foreach ($officialRows as $index => $officialRow)
-                                        <section class="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4">
-                                            <flux:heading size="xs" class="text-white">{{ $officialRow['role'] }}</flux:heading>
+                                        <section class="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                                            <flux:heading size="xs">{{ $officialRow['role'] }}</flux:heading>
 
                                             <div class="grid gap-3 md:grid-cols-2">
                                                 <div>
                                                     <flux:input wire:model="officialRows.{{ $index }}.first_name" label="First name" />
                                                     @error('officialRows.'.$index.'.first_name')
-                                                        <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                        <flux:text class="mt-1">{{ $message }}</flux:text>
                                                     @enderror
                                                 </div>
                                                 <div>
                                                     <flux:input wire:model="officialRows.{{ $index }}.last_name" label="Last name" />
                                                     @error('officialRows.'.$index.'.last_name')
-                                                        <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                        <flux:text class="mt-1">{{ $message }}</flux:text>
                                                     @enderror
                                                 </div>
                                             </div>
@@ -349,7 +448,7 @@
                                             <div>
                                                 <flux:input wire:model="officialRows.{{ $index }}.country_code" label="Country code" />
                                                 @error('officialRows.'.$index.'.country_code')
-                                                    <flux:text class="mt-1 text-red-300">{{ $message }}</flux:text>
+                                                    <flux:text class="mt-1">{{ $message }}</flux:text>
                                                 @enderror
                                             </div>
                                         </section>
@@ -364,35 +463,35 @@
                     @endif
 
                     @if ($step === 'ready' || $isSetupLocked)
-                        <flux:card class="border border-white/10 bg-slate-900/70 p-6">
+                        <flux:card class="border border-slate-200/80 bg-white/90 p-6 shadow-sm">
                             <div class="space-y-6">
                                 <div class="space-y-2">
-                                    <flux:heading size="lg" class="text-white">Match ready</flux:heading>
-                                    <flux:text class="text-slate-300">
+                                    <flux:heading size="lg">Match ready</flux:heading>
+                                    <flux:text>
                                         Static setup is complete. Use the scoring screen for tosses, lineups, and all event recording.
                                     </flux:text>
                                 </div>
 
                                 <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                                    <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                                    <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
                                         <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Fixture</div>
-                                        <div class="mt-2 font-medium text-white">{{ $homeTeamName }} vs {{ $awayTeamName }}</div>
+                                        <div class="mt-2 font-medium text-slate-950">{{ $homeTeamName }} vs {{ $awayTeamName }}</div>
                                     </div>
-                                    <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                                    <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
                                         <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Venue</div>
-                                        <div class="mt-2 font-medium text-white">{{ $city }}, {{ $hall }}</div>
+                                        <div class="mt-2 font-medium text-slate-950">{{ $city }}, {{ $hall }}</div>
                                     </div>
-                                    <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                                    <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
                                         <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Rosters</div>
-                                        <div class="mt-2 font-medium text-white">{{ collect($homePlayerRows)->filter(fn ($row) => trim($row['number']) !== '')->count() }} / {{ collect($awayPlayerRows)->filter(fn ($row) => trim($row['number']) !== '')->count() }}</div>
+                                        <div class="mt-2 font-medium text-slate-950">{{ collect($homePlayerRows)->filter(fn ($row) => trim($row['number']) !== '')->count() }} / {{ collect($awayPlayerRows)->filter(fn ($row) => trim($row['number']) !== '')->count() }}</div>
                                     </div>
-                                    <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                                    <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4">
                                         <div class="text-xs uppercase tracking-[0.18em] text-slate-500">Officials</div>
-                                        <div class="mt-2 font-medium text-white">{{ collect($officialRows)->filter(fn ($row) => trim($row['first_name']) !== '' && trim($row['last_name']) !== '')->count() }} assigned</div>
+                                        <div class="mt-2 font-medium text-slate-950">{{ collect($officialRows)->filter(fn ($row) => trim($row['first_name']) !== '' && trim($row['last_name']) !== '')->count() }} assigned</div>
                                     </div>
                                 </div>
 
-                                <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4 text-sm text-slate-300">
+                                <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
                                     @if ($isSetupLocked)
                                         Setup changes are disabled because match events already exist.
                                     @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use App\Livewire\Competition;
 use App\Livewire\Game;
 use App\Livewire\MatchSetup;
 use App\Services\CurrentMatchResolver;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', fn (CurrentMatchResolver $currentMatchResolver) => redirect()->route($currentMatchResolver->landingRouteName()))->name('home');
+Route::livewire('/competition', Competition::class)->name('competition');
 Route::livewire('/setup', MatchSetup::class)->name('match.setup');
 Route::livewire('/game', Game::class)->name('game');

--- a/tests/Feature/CompetitionPageTest.php
+++ b/tests/Feature/CompetitionPageTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Competition as CompetitionComponent;
+use App\Models\Competition;
+use App\Models\Game;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('competition page is available', function (): void {
+    $this->get(route('competition'))
+        ->assertSuccessful()
+        ->assertSee('Set the competition details');
+});
+
+test('competition page seeds the singleton from config when missing', function (): void {
+    config()->set('competition.name', 'World Cup Finals');
+
+    Livewire::test(CompetitionComponent::class)
+        ->assertSet('name', 'World Cup Finals')
+        ->call('save')
+        ->assertSet('saved', true);
+
+    expect(Competition::query()->count())->toBe(1)
+        ->and(Competition::query()->sole()->name)->toBe('World Cup Finals');
+});
+
+test('competition page updates the current competition details', function (): void {
+    $competition = Competition::factory()
+        ->named('Nations League Finals')
+        ->create();
+
+    Livewire::test(CompetitionComponent::class)
+        ->assertSet('name', $competition->name)
+        ->set('name', 'European Competition')
+        ->call('save')
+        ->assertSet('saved', true);
+
+    expect(Competition::query()->count())->toBe(1)
+        ->and(Competition::query()->sole()->name)->toBe('European Competition');
+});
+
+test('game competition name prefers the stored competition', function (): void {
+    config()->set('competition.name', 'Fallback Competition');
+
+    Competition::factory()
+        ->named('Stored Competition')
+        ->create();
+
+    $game = Game::factory()->create();
+
+    expect($game->competitionName())->toBe('Stored Competition');
+});

--- a/tests/Feature/MatchSetupRoutingTest.php
+++ b/tests/Feature/MatchSetupRoutingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\OfficialRole;
 use App\Livewire\MatchSetup;
+use App\Models\Competition;
 use App\Models\Game;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
@@ -23,11 +24,13 @@ test('first load with no match configured redirects to setup and shows the singl
 
     $this->get(route('match.setup'))
         ->assertSuccessful()
+        ->assertSee('Competition details')
         ->assertSee('Create the current match')
-        ->assertSee('Create current match');
+        ->assertSee('Save competition');
 });
 
 test('game redirects to setup when current match setup is incomplete', function (): void {
+    Competition::factory()->named('Nations League Finals')->create();
     createCurrentMatchWithoutDetails();
 
     $this->get(route('game'))
@@ -35,6 +38,7 @@ test('game redirects to setup when current match setup is incomplete', function 
 });
 
 test('setup page shows the next required step for an incomplete current match', function (): void {
+    Competition::factory()->named('Nations League Finals')->create();
     createCurrentMatchWithoutDetails();
 
     $this->get(route('match.setup'))
@@ -43,7 +47,19 @@ test('setup page shows the next required step for an incomplete current match', 
         ->assertDontSee('Open current match');
 });
 
+test('game redirects to setup when the competition details are missing', function (): void {
+    makeReadyCurrentMatch(withCompetition: false);
+
+    $this->get(route('game'))
+        ->assertRedirect(route('match.setup'));
+
+    $this->get(route('match.setup'))
+        ->assertSuccessful()
+        ->assertSee('Competition details');
+});
+
 test('home redirects to the match when setup is ready', function (): void {
+    Competition::factory()->named('Nations League Finals')->create();
     makeReadyCurrentMatch();
 
     $this->get(route('home'))
@@ -51,6 +67,8 @@ test('home redirects to the match when setup is ready', function (): void {
 });
 
 test('setup can create the current match when none exists', function (): void {
+    Competition::factory()->named('Nations League Finals')->create();
+
     Livewire::test(MatchSetup::class)
         ->call('createMatch')
         ->assertSet('step', 'match-details')
@@ -60,6 +78,7 @@ test('setup can create the current match when none exists', function (): void {
 });
 
 test('setup reuses the current match instead of inserting another one', function (): void {
+    Competition::factory()->named('Nations League Finals')->create();
     $game = createCurrentMatchWithoutDetails();
 
     Livewire::test(MatchSetup::class)
@@ -71,6 +90,7 @@ test('setup reuses the current match instead of inserting another one', function
 });
 
 test('setup createMatch reuses a singleton created after the component mounts', function (): void {
+    Competition::factory()->named('Nations League Finals')->create();
     $component = Livewire::test(MatchSetup::class);
 
     $game = createCurrentMatchWithoutDetails();
@@ -84,9 +104,10 @@ test('setup createMatch reuses a singleton created after the component mounts', 
 });
 
 test('setup flow can take a blank current match to a playable ready state', function (): void {
-    createCurrentMatchWithoutDetails();
-
     $component = Livewire::test(MatchSetup::class)
+        ->set('competitionName', 'Nations League Finals')
+        ->call('saveCompetition')
+        ->call('createMatch')
         ->set('matchNumber', '7')
         ->set('matchCountryCode', 'ITA')
         ->set('city', 'Rome')
@@ -132,4 +153,26 @@ test('setup flow can take a blank current match to a playable ready state', func
 
     $this->get(route('game'))
         ->assertSuccessful();
+});
+
+test('competition can be edited inline after it has already been saved', function (): void {
+    $component = Livewire::test(MatchSetup::class)
+        ->set('competitionName', 'Nations League Finals')
+        ->call('saveCompetition')
+        ->call('createMatch')
+        ->assertSet('step', 'match-details');
+
+    $component
+        ->call('openStep', 'competition')
+        ->assertSet('step', 'competition')
+        ->assertSet('editingCompetition', false)
+        ->call('editCompetition')
+        ->assertSet('editingCompetition', true)
+        ->set('competitionName', 'European Competition')
+        ->call('saveCompetition')
+        ->assertSet('competitionName', 'European Competition')
+        ->assertSet('editingCompetition', false)
+        ->assertSet('step', 'match-details');
+
+    expect(Competition::query()->sole()->name)->toBe('European Competition');
 });

--- a/tests/Feature/SingletonCurrentMatchAccessGuardTest.php
+++ b/tests/Feature/SingletonCurrentMatchAccessGuardTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\File;
 
 test('singleton match livewire components do not use direct static Game access', function (): void {
-    // Historical migrations may still mention championship-era schema names; that is preserved
+    // Historical migrations may still mention competition-era schema names; that is preserved
     // migration history, not the active single-match runtime architecture this guard enforces.
     $componentPaths = collect(File::files(app_path('Livewire')))
         ->map(fn (SplFileInfo $file): string => $file->getPathname())

--- a/tests/Feature/Support/SingleMatchTestSupport.php
+++ b/tests/Feature/Support/SingleMatchTestSupport.php
@@ -6,6 +6,7 @@ use App\Enums\MatchPhase;
 use App\Enums\OfficialRole;
 use App\Enums\TeamAB;
 use App\Enums\TeamSide;
+use App\Models\Competition;
 use App\Models\Game;
 use App\Models\Official;
 use App\Models\Player;
@@ -136,8 +137,12 @@ function assignRequiredOfficials(Game $game): Game
     return $game->fresh();
 }
 
-function makeReadyCurrentMatch(): Game
+function makeReadyCurrentMatch(bool $withCompetition = true): Game
 {
+    if ($withCompetition) {
+        Competition::ensureSingleton();
+    }
+
     $game = createCurrentMatch();
 
     submitInitialRosters($game);


### PR DESCRIPTION
## Summary
This branch introduces a proper pre-game setup flow and standardises the domain language around `competition`.

## What changed
- added a dedicated Livewire `Competition` component and `/competition` page for creating competition details
- updated the setup flow so incomplete setup redirects to `/setup` before a user can reach `/game`
- reworked the setup screen to show setup progress, allow inline competition editing, and improve the introductory guidance
- replaced remaining `championship` terminology across code, relationships, labels, variables, and schema references with `competition`
- adjusted the setup UI to use a light presentation and avoid overriding Flux heading/text colours
- added and updated feature coverage for competition and setup routing behaviour

## Why
Issue #16 required the single-game flow to include a real setup experience before a game can start. The branch also removes the mixed `championship`/`competition` terminology that was leaking through the codebase and UI.

## Impact
Users are now guided through the required setup steps before starting a game, can create and edit the competition inline during setup, and see consistent competition terminology throughout the application.

## Validation
- `php artisan test --compact tests/Feature/CompetitionPageTest.php`
- `php artisan test --compact tests/Feature/MatchSetupRoutingTest.php`
- `php ./vendor/bin/phpstan analyse app/ database/factories/ database/seeders/ --memory-limit=2G --debug`
- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/rector process --clear-cache --memory-limit=2G`

Closes #16